### PR TITLE
Improve trainer robustness

### DIFF
--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -9,7 +9,7 @@ Run:
     python -m scripts.trainer --gpu 0
 """
 from __future__ import annotations
-import argparse, pathlib, time, random, gzip, pickle, glob, os
+import argparse, pathlib, time, random, gzip, pickle, glob, os, zipfile
 from collections import deque
 from typing import Tuple
 
@@ -46,7 +46,11 @@ class ReplayBuffer:
     def __len__(self) -> int: return len(self.states)
 
     def add_game(self, npz_file: pathlib.Path) -> None:
-        data = np.load(npz_file)
+        try:
+            data = np.load(npz_file)
+        except (OSError, zipfile.BadZipFile) as e:
+            print(f"Warning: could not read {npz_file}: {e}")
+            return
         s, p, z = data["s"], data["p"], data["z"]
         for si, pi, zi in zip(s, p, z):
             self.states.append(torch.from_numpy(si))


### PR DESCRIPTION
## Summary
- handle corrupted `.npz` files gracefully during training
- import `zipfile` for BadZipFile exception handling

## Testing
- `python network/test.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6847f32f20a88329bfe5417f0242c022