### PR TITLE
Switch to pybind11 MCTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,41 @@
 
 This repository implements a minimal AlphaZero-style chess engine.
 
+## Requirements
+
+Install Python dependencies:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+You will also need a C++17 compiler installed on your system.
+
 ## Building the C++ MCTS
 
-A new pybind11 extension provides a faster Monte Carlo Tree Search.
-Build the extension with:
+The Monte Carlo Tree Search core is implemented in `cpp/mcts.cpp` using
+pybind11. Compile the extension in place with:
 
 ```bash
 python setup.py build_ext --inplace
 ```
 
-Ensure `pybind11`, PyTorch and a C++17 compiler are available.
-You can also install the package in editable mode which will compile the
+Alternatively install the package in editable mode which will build the
 extension automatically:
 
 ```bash
 python -m pip install -e .
+```
+
+When imported, `from mcts import MCTS` will automatically use the compiled
+extension.
+
+## Running
+
+Example scripts can be found in the `scripts/` directory. Start self-play or
+arena matches with:
+
+```bash
+python scripts/selfplay_worker.py --help
+python scripts/arena.py --help
 ```

--- a/scripts/arena.py
+++ b/scripts/arena.py
@@ -8,7 +8,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import List, Tuple
 
 import torch, chess
-from mcts.mcts import MCTS
+from mcts import MCTS
 from network.network import JohnNet
 from data import move_encoder as enc
 

--- a/scripts/selfplay_worker.py
+++ b/scripts/selfplay_worker.py
@@ -12,7 +12,7 @@ import numpy as np
 import torch, chess
 
 from data import board, move_encoder as enc
-from mcts.mcts import MCTS
+from mcts import MCTS
 from network.network import JohnNet
 
 # ── runtime dirs ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- use `from mcts import MCTS` so the pybind11 module is preferred
- document how to build and run the new C++ MCTS

## Testing
- `python -m pip install -e .` *(fails: network disabled)*
- `python setup.py build_ext --inplace` *(fails: ModuleNotFoundError: pybind11)*

------
https://chatgpt.com/codex/tasks/task_e_685159bf49a083299b0fce9f9360ceaf